### PR TITLE
fixed the extraction of workitem iteration permissions when no child …

### DIFF
--- a/Source/PermissionsExtractionTool/PermissionsExtractionTool/Program.cs
+++ b/Source/PermissionsExtractionTool/PermissionsExtractionTool/Program.cs
@@ -329,8 +329,10 @@ namespace Microsoft.ALMRangers.PermissionsExtractionTool
 
             // root Area Node
             var iterationPermissionRoot = new IterationPermission { IterationName = teamProject.Name, IterationPermissions = new List<Permission>() };
-            iterationPermissionRoot.IterationPermissions.AddRange(ExtractGenericSecurityNamespacePermissions(server, PermissionScope.WorkItemIterations, userIdentity, lstIterations.First().ParentNode.Uri.AbsoluteUri, identityManagementService, groups));
-
+            if (lstIterations.Any())
+            { 
+                iterationPermissionRoot.IterationPermissions.AddRange(ExtractGenericSecurityNamespacePermissions(server, PermissionScope.WorkItemIterations, userIdentity, lstIterations.First().ParentNode.Uri.AbsoluteUri, identityManagementService, groups));
+            }
             if (iterationPermissionRoot.IterationPermissions.Count > 0)
             {
                 result.Add(iterationPermissionRoot);


### PR DESCRIPTION
…iterations were set.

When extracting permissions of a team project with no iteration paths (TFS on premise) the execution breaks with an exception because the sequence of lstIterations.First contains no elements.